### PR TITLE
Adds ability to hide disabled users from All Users

### DIFF
--- a/init.php
+++ b/init.php
@@ -3,9 +3,9 @@
  * Plugin Name: Disable Users
  * Plugin URI:  http://wordpress.org/extend/disable-users
  * Description: This plugin provides the ability to disable specific user accounts.
- * Version:     1.0.5
- * Author:      Jared Atchison
- * Author URI:  http://jaredatchison.com 
+ * Version:     1.2.0
+ * Author:      Jared Atchison, Stephen Schrauger
+ * Author URI:  http://jaredatchison.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * @author     Jared Atchison
- * @version    1.0.5
+ * @author     Jared Atchison, Stephen Schrauger
+ * @version    1.2.0
  * @package    JA_DisableUsers
  * @copyright  Copyright (c) 2015, Jared Atchison
  * @link       http://jaredatchison.com
@@ -47,6 +47,18 @@ final class ja_disable_users {
 		// Filters
 		add_filter( 'login_message',              array( $this, 'user_login_message'          )        );
 		add_filter( 'manage_users_columns',       array( $this, 'manage_users_columns'	      )        );
+
+		// Plugin Settings
+		// Register the 'settings' page
+		add_action( 'admin_menu', array( $this, 'add_plugin_page' ) );
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+		// Add a link from the plugin page to this plugin's settings page
+		add_filter( 'plugin_row_meta', array( $this, 'plugin_action_links' ), 10, 2 );
+
+		// Modify the All Users query to hide disabled users by default (if preference set)
+		add_filter('pre_user_query', array($this, 'user_query_exceptions' ) );
+
 	}
 
 	/**
@@ -167,7 +179,14 @@ final class ja_disable_users {
 	 */
 	public function manage_users_columns( $defaults ) {
 
-		$defaults['ja_user_disabled'] = __( 'Disabled', 'ja_disable_users' );
+
+		if (esc_attr( get_option( 'ja-disable-users-setting-hide-disabled' ))) {
+			$title = __("Click to show disabled accounts.");
+		} else {
+			$title = __("Click to hide disabled accounts.");
+		}
+		$toggle_link = '<a href="?toggle_disabled=1" title="' . $title . '">*</a>';
+		$defaults['ja_user_disabled'] = __( 'Disabled' . $toggle_link, 'ja_disable_users' );
 		return $defaults;
 	}
 
@@ -196,6 +215,171 @@ final class ja_disable_users {
  	 */
 	public function manage_users_css() {
 		echo '<style type="text/css">.column-ja_user_disabled { width: 80px; }</style>';
+	}
+
+	/**
+	 * Tells WordPress about a new page and what function to call to create it
+	 *
+	 * @since 1.1.0
+	 */
+	public function add_plugin_page() {
+		// This page will be under "Settings" menu. add_options_page is merely a WP wrapper for add_submenu_page specifying the 'options-general' menu as parent
+		add_options_page(
+			"Disable Users Settings", // page title
+			"Disable Users Settings", // menu title
+			"manage_options", // user capability required to edit these settings
+			"ja-disable-users-settings", // new page slug
+			array(
+				$this,
+				'create_settings_page'
+			) // since we are putting settings on our own page, we also have to define how to print out the settings
+		);
+	}
+
+	/**
+	 * Adds a link to this plugin's setting page directly on the WordPress plugin list page
+	 *
+	 * @param $links
+	 * @param $file
+	 *
+	 * @return array
+	 */
+	public function plugin_action_links( $links, $file ) {
+		if ( strpos( __FILE__, $file ) !== false ) {
+			$links = array_merge(
+				$links,
+				array(
+					'settings' => '<a href="' . admin_url( 'options-general.php?page=ja-disable-users-settings' ) . '">' . __( 'Settings', 'ja-disable-users-settings') . '</a>'
+				)
+			);
+		}
+
+		return $links;
+	}
+
+	/**
+	 * Tells WordPress how to output the page
+	 *
+	 * @since 1.2.0
+	 */
+	public function create_settings_page() {
+		?>
+		<div class="wrap" >
+
+			<h2 >Disable Users - Settings</h2 >
+
+			<form method="post" action="options.php" >
+				<?php
+				settings_fields( 'ja-disable-users-settings-group' );
+				do_settings_sections( 'ja-disable-users-settings' );
+				submit_button();
+				?>
+			</form >
+		</div >
+		<?php
+	}
+
+	/**
+	 * Adds settings to settings page for this plugin.
+	 * @since 1.2.0
+	 */
+	public function admin_init() {
+
+
+		add_settings_section(
+			'ja-disable-users-settings-section', // unique name of section
+			'Disable Users - Settings', // start of section text shown to user
+			'', // Extra text after section title
+			'ja-disable-users-settings' // what page this section is on
+		);
+
+		$this->add_setting('ja-disable-users-setting-hide-disabled', __("Hide disabled users by default on All Users")); // adds a checkbox that lets users view All Users minus any disabled users
+	}
+
+	/**
+	 * Adds a setting
+	 *
+	 * @param $setting_name
+	 * @param $label
+	 */
+	public function add_setting( $setting_id, $label ) {
+		// add setting, and register it
+		add_settings_field(
+			$setting_id,  // Unique ID used to identify the field
+			$label,  // The label to the left of the option.
+			array($this, 'settings_input_checkbox'),   // The function responsible for rendering checkboxes
+			'ja-disable-users-settings',                         // The page on which this option will be displayed
+			'ja-disable-users-settings-section',         // The name of the section to which this field belongs
+			array(   // The array of arguments to pass to the callback. These 3 are referenced in setting_input_checkbox.
+			         'id'      => $setting_id,
+			         'label'   => $label,
+			         'value'   => esc_attr( get_option( $setting_id ))
+			)
+		);
+		register_setting(
+			'ja-disable-users-settings-group',
+			$setting_id
+		//array( $this, 'sanitize' ) // sanitize function
+		);
+
+	}
+
+	/*
+	**
+	* Creates the HTML code that is printed for each setting input
+	*
+	* @param $args
+	*/
+	public function settings_input_checkbox( $args ) {
+		// Note the ID and the name attribute of the element should match that of the ID in the call to add_settings_field.
+		// Because we only call register_setting once, all the options are stored in an array in the database. So we
+		// have to name our inputs with the name of an array. ex <input type="text" id=option_key name="option_group_name[option_key]" />.
+		// WordPress will automatically serialize the inputs that are in this array form and store it under
+		// the option_group_name field. Then get_option will automatically unserialize and grab the value already set and pass it in via the $args as the 'value' parameter.
+		if ($args[ 'value' ]) {
+			$checked = 'checked="checked"';
+		} else {
+			$checked = '';
+		}
+
+		$html = '';
+
+		// create a hidden variable with the same name and no value. if the box is unchecked, the hidden value will be POSTed.
+		// If the value is checked, only the checkbox will be sent.
+		// This way, we don't have to uncheck everything server-side and then re-check the POSTed values.
+		// This is particularly useful to prevent preferences from being deleted if a post type is removed from a theme's code.
+		// If we just unchecked everything, old post types would lose their preferences; if they are later reactivated, the preference
+		// would be gone. This way, the preference persists.
+		$html .= '<input type="hidden"   id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" value=""/>';
+		$html .= '<input type="checkbox" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" value="' . ( $args[ 'id' ] ) . '" ' . $checked . '/>';
+
+		// Here, we will take the first argument of the array and add it to a label next to the input
+		$html .= '<label for="' . $args[ 'id' ] . '"> ' . $args[ 'label' ] . '</label>';
+		echo $html;
+	}
+
+	public function user_query_exceptions($query_obj){
+		// if preference is set to hide disabled users by default, then alter the All Users query to prevent disabled users from showing up
+		global $wpdb;
+		$str_hide_query = " AND ID NOT IN (SELECT user_id from $wpdb->usermeta WHERE meta_key = 'ja_disable_user' AND meta_value = '1')";
+
+		if (esc_attr( get_option( 'ja-disable-users-setting-hide-disabled' ))) {
+			// preference set to hide disabled users by default. now check if they are manually showing them.
+			if ( empty( $_REQUEST[ 'toggle_disabled' ] ) ) {
+				// 'show_disabled' not specified, so exclude disabled users
+				// search for ja_disable_user=true. if ID is listed, they are disabled.
+				$query_obj->query_where .= $str_hide_query;
+			}
+		} else {
+			// preference set to show disabled users by default. now check if they are manually hiding them.
+			if ( !empty( $_REQUEST[ 'toggle_disabled' ] ) ) {
+				// 'hide_disabled' specified, so exclude disabled users
+				// search for ja_disable_user=true. if ID is listed, they are disabled.
+				$query_obj->query_where .= $str_hide_query;
+			}
+		}
+		return $query_obj;
+
 	}
 }
 new ja_disable_users();

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,8 @@ This can be useful in a few situations.
 * You are working on a site for a client who has an account, but do not want him to login and/or make changes during development.
 * You have a client who has an unpaid invoice.
 
+Disabled users can also be hidden from the All Users listing, either by default (via the plugin settings page) or manually (by clicking on the link in the Disabled column). A new menu item is added as well, letting you view only disabled users.
+
 **[This plugin is on GitHub!](https://github.com/jaredatch/Disable-Users/)** Pull requests are welcome. If possible please report issues through Github.
 
 == Installation ==
@@ -39,6 +41,13 @@ Yes, there is a filter in place for that, `ja_disable_users_notice`.
 2. Message when a disabled user tries to login.
 
 == Changelog ==
+
+= 1.2.1 (03/08/2016) =
+* Added menu item to show only disabled users
+
+= 1.2.0 (03/08/2016) =
+* Added plugin setting page
+** Preference to hide disabled users by default when viewing All Users
 
 = 1.0.5 (11/11/2015) =
 * Added pl_PL transnation - Props Dominik Kocuj

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Disable Users ===
-Contributors: jaredatch
+Contributors: jaredatch, schrauger
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=AD8KTWTTDX9JL
 Tags: users, login, disable
 Requires at least: 4.0.0


### PR DESCRIPTION
I added a bunch of code that adds the ability to hide disabled users from the All Users listing.
* Settings page added to let the admin either show disabled users intermixed (default, current functionality) or to remove them from the listing.
* Added a link to the Disabled column to show or hide disabled users, depending on what the plugin setting preference was set to.
* Added a submenu link to display *only* disabled users.

Since there was a fair amount of new stuff, feel free to pick and choose (or reject outright) things from the pull request. I just thought I'd share my additions.

Note: I didn't make sure any internationalization or language translations were added or adjusted. That will probably need to be tweaked if you want to have other languages for the new features.