### PR TITLE
Don't send comment emails to disabled users

### DIFF
--- a/init.php
+++ b/init.php
@@ -119,7 +119,7 @@ final class ja_disable_users {
 	 * @param object $user
      * @return boolean true if disabled, false if enabled
 	 */
-	public function is_user_disabled( $user_id ) {
+	private function is_user_disabled( $user_id ) {
 
 		// Get user meta
 		$disabled = get_user_meta( $user_id, 'ja_disable_user', true );


### PR DESCRIPTION
This plugin addresses issue #5.

In the process, I also created a generic is_user_disabled() function that checks the usermeta value. This was being done in two places already, and this PR added a third.

(Same PR as submitted yesterday, I just moved this to a branch in my fork so I could work on some other PRs)